### PR TITLE
Fix mouse moving the application window.

### DIFF
--- a/src/platform/qglmainwindow.h
+++ b/src/platform/qglmainwindow.h
@@ -118,21 +118,15 @@ protected:
 	}
 
 	void mouseReleaseEvent(QMouseEvent* event) override{
-		this->updateSlvSpaceMouseEvent(event);
-        QWidget::mouseReleaseEvent(event);
+		updateSlvSpaceMouseEvent(event);
 	}
 
-	virtual void mousePressEvent(QMouseEvent* event) override{
-
-		this->updateSlvSpaceMouseEvent(event);        
-		QWidget::mousePressEvent(event);
-		
+	void mousePressEvent(QMouseEvent* event) override{
+		updateSlvSpaceMouseEvent(event);
 	}
 
 	void mouseMoveEvent(QMouseEvent* event) override{
-
-		this->updateSlvSpaceMouseEvent(event);
-        QWidget::mouseMoveEvent(event);
+		updateSlvSpaceMouseEvent(event);
 	}
 
 	void updateSlvSpaceMouseEvent(QMouseEvent* event)

--- a/src/platform/qglmainwindow.h
+++ b/src/platform/qglmainwindow.h
@@ -108,11 +108,10 @@ protected:
 	//----Mouse Events--------
 	void wheelEvent(QWheelEvent* event)
 	{
-                 int wheelDelta=120; 
+         const double wheelDelta=120.0;
 		 slvMouseEvent.button = MouseEvent::Button::NONE;
 		 slvMouseEvent.type = MouseEvent::Type::SCROLL_VERT;
-		 if (!event->angleDelta().isNull())
-            slvMouseEvent.scrollDelta = (double)event->delta() / (double)wheelDelta;
+         slvMouseEvent.scrollDelta = (double)event->angleDelta().y() / wheelDelta;
 
 		 emit mouseEventOccuredSignal(slvMouseEvent);
 	}
@@ -300,8 +299,6 @@ public:
 		//scrollArea->setWidgetResizable(true);
 		this->setCentralWidget(glWidget);
 		//void QLayout::setContentsMargins(int left, int top, int right, int bottom)
-		this->wheelDelta=120;
-		
 	}
 
 	~QtGLMainWindow()
@@ -471,8 +468,6 @@ private:
 	GLWidget* glWidget;
 	QScrollArea* scrollArea;
 	QGridLayout* gridLayout;
-        double wheelDelta; 
-
 };
 
 


### PR DESCRIPTION
When dragging with the LMB the window would often move rather than manipulating the document.  This occurred with Qt 5.15 on KDE 5.27.